### PR TITLE
dm-control 1.0.30

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: dm-control
-  version: "1.0.28"
-  mujoco_min_version: "3.2.7"
+  version: "1.0.30"
+  mujoco_min_version: "3.3.2"
 
 package:
   name: ${{ name|lower }}
@@ -9,10 +9,10 @@ package:
 
 source:
   url: https://pypi.org/packages/source/d/dm_control/dm_control-${{ version }}.tar.gz
-  sha256: 15e14c600885e9a0be2cd84577f57556a602bd5dbd26a0dcf348b10bea2dde65
+  sha256: 26d72e7917f0e4383b51b089f3176a706426537d51b0c2f36ecb1fd7c493b47e
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 


### PR DESCRIPTION
Update dm-control to 1.0.30 and refresh source hash and Mujoco minimum version metadata.

*This PR description was generated by an agent (GitHub Copilot) on behalf of @traversaro . If it looks wrong/sloppy/inappropriate, please report it here: https://github.com/traversaro/conda-forge-agent-ws*